### PR TITLE
fixed stuck in buffer overflow error #5

### DIFF
--- a/examples/FrskySP_sniffer/FrskySP_sniffer.ino
+++ b/examples/FrskySP_sniffer/FrskySP_sniffer.ino
@@ -45,10 +45,18 @@ void loop () {
     decode (packet.byte);
   } else if (FrskySP.available () > 8) {
     Serial << "buffer overflow (" << FrskySP.available () << ") - too many sensors on the same physical ID ?" << endl;
+    // Throw away wrong bits
+    while(FrskySP.available()) {
+      FrskySP.read();
+    }
   } else if (FrskySP.available () == 0) {
     //Serial << "no sensor" << endl;
   } else {
     Serial << "buffer underflow - sensor too slow ?" << endl;
+    // Throw away wrong bits
+    while(FrskySP.available()) {
+      FrskySP.read();
+    }
   }
 
   while (FrskySP.available ()) {


### PR DESCRIPTION
If an overflow error is triggered inside the FrskySP_sniffer example, the buffer won't get cleared, and therefore the loop will continue to go inside the else if. To fix this, I added some code to throw the wrong bits away.